### PR TITLE
fix: correct integrals

### DIFF
--- a/03/pages/01_Change_of_Measure.py
+++ b/03/pages/01_Change_of_Measure.py
@@ -45,7 +45,7 @@ st.markdown('''
             we can look up the probability $p_X(v(y))$ of that value. By plotting $p_X(v(y))$ for each $y \in Y$, we
             get the orange dashed line on the y-axis of the plot.
             
-            As you have probably noticed, the integral over $f(x)$ is greater than 1. This, however, should not be
+            As you have probably noticed, the integral over $p_X(y)$ is smaller than 1. This, however, should not be
             the case as densities always integrate to 1. In order to fix this,
             we need to multiply $p_X(v(y))$ with the derivative of $v(y)$ for all $y \in Y$, as decribed in the theorem.
             Doing this, we now get an integral much closer to 1. Activating the box "use correction" at the bottom left
@@ -122,15 +122,15 @@ p = norm.pdf(x, loc=0, scale=1)
 # p_y(y=u(x)) = p_x(v(y)) * |du/dx|^{-1} for v(y) = u^{-1}(x)
 py = p / jnp.abs(df)
 
-# = sum p[i] * d(x[i]), with each "box" d(x[i]) of size 6 / N
-px_int = jnp.sum(p) * 6 / (N - 1)
-f_int = jnp.sum(f) * 3 / (N - 1)
-py_int = jnp.sum(py) * 3 / (N - 1)
+# integrals
+px_int = jnp.trapz(y=p, x=x)
+f_int = jnp.trapz(y=p, x=f)
+py_int = jnp.trapz(y=py, x=f)
 
 fig, ax = plt.subplots()
 
-ax.text(-2.5, 2.5, f"The integral over $p_x(x)$ is approximately {px_int:.2f}.")
-ax.text(-2.5, 2.25, f"The integral over $f(x)$ is approximately {f_int:.2f}.")
+ax.text(-2.5, 2.5, f"The integral over $p(x)$ is approximately {px_int:.2f}.")
+ax.text(-2.5, 2.25, f"The integral over $p_x(y)$ is approximately {f_int:.2f}.")
 
 # plot the features:
 if show_features:


### PR DESCRIPTION
When reviewing Lecture 03 for the exam, I was wondering about the integral values in the app for the Change of Measure theorem.

The integral before correction has a much higher value than the integral after correction although the area under the curve is clearly smaller. Additionally, even after correction the integral of the density does not sum up to 1 as it should - sometimes not even approximately.

![Integrals_Before](https://github.com/philipphennig/ProbML_Apps/assets/80645712/525e0ecf-5cdc-4a64-8b13-1feb13b5b05e)

After doing some investigation, I found the solution.  The corresponding integral calculations were done over equistidant points although such are not guaranteed. I fixed this by calculating the integrals with the trapezoidal rule with respect to the mapped values f(x). The results now show more meaningful values.

![Integrals_Now](https://github.com/philipphennig/ProbML_Apps/assets/80645712/1418c3b0-eaa8-4872-94e0-c43cdc91a012)

Could you please take a look on this?